### PR TITLE
feat/#24/구글 애널리틱스 연결

### DIFF
--- a/gonggibap/src/app/_components/GoogleAnalytics.tsx
+++ b/gonggibap/src/app/_components/GoogleAnalytics.tsx
@@ -6,15 +6,26 @@ import { usePathname } from 'next/navigation';
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID || '';
 
-// gtag 타입 정의
+// gtag 타입 정의를 더 구체적으로 수정
 declare global {
   interface Window {
     gtag: (
       command: 'config' | 'event',
       targetId: string,
-      config?: Record<string, any>
+      // Record<string, any> 대신 더 구체적인 타입 정의
+      config?: {
+        page_path?: string;
+        event_category?: string;
+        event_label?: string;
+        value?: number;
+        [key: string]: unknown;  // 기타 가능한 속성들을 위한 인덱스 시그니처
+      }
     ) => void;
-    dataLayer: any[];
+    // any[] 대신 구체적인 타입 정의
+    dataLayer: Array<{
+      event?: string;
+      [key: string]: unknown;
+    }>;
   }
 }
 
@@ -27,12 +38,10 @@ export function GoogleAnalytics() {
     }
   }, [pathname]);
 
-  // GA_ID가 없으면 아무것도 렌더링하지 않음
   if (!GA_ID) {
     return null;
   }
 
-  // 페이지뷰 추적 함수
   const pageview = (path: string) => {
     window?.gtag?.('config', GA_ID, {
       page_path: path,
@@ -63,7 +72,6 @@ export function GoogleAnalytics() {
   );
 }
 
-// 이벤트 추적을 위한 타입 정의
 interface EventProps {
   action: string;
   category?: string;
@@ -71,7 +79,6 @@ interface EventProps {
   value?: number;
 }
 
-// 이벤트 추적을 위한 유틸리티 함수
 export const event = ({ action, category, label, value }: EventProps) => {
   if (!GA_ID) return;
   

--- a/gonggibap/src/app/_components/RestaurantListView.tsx
+++ b/gonggibap/src/app/_components/RestaurantListView.tsx
@@ -13,19 +13,18 @@ export const RestaurantListView: React.FC<RestaurantListViewProps> = ({
   selectedRestaurantId,
 }) => {
   const handleRestaurantSelect = (restaurant: Restaurant) => {
-
     // GA4 이벤트 발생, 기본적인 선택 이벤트
     event({
-      action: 'select_restaurant',
-      category: 'engagement',
+      action: "select_restaurant",
+      category: "engagement",
       label: restaurant.restaurantName,
       value: 1,
     });
 
     // 상세 정보가 포함된 커스텀 이벤트
     event({
-      action: 'view_restaurant_details',
-      category: 'restaurant_interaction',
+      action: "view_restaurant_details",
+      category: "restaurant_interaction",
       label: `${restaurant.restaurantCategory} | ${restaurant.restaurantName}`,
       value: restaurant.visitCount,
     });
@@ -34,13 +33,12 @@ export const RestaurantListView: React.FC<RestaurantListViewProps> = ({
     onRestaurantSelect(restaurant);
   };
 
-
   return (
     <div className="space-y-4">
       {restaurants.map((restaurant) => (
         <button
           key={restaurant.restaurantId}
-          onClick={() => onRestaurantSelect(restaurant)}
+          onClick={() => handleRestaurantSelect(restaurant)}
           className={`w-full text-left p-4 rounded-lg transition-colors border dark:border-none
             ${
               selectedRestaurantId === restaurant.restaurantId
@@ -50,12 +48,8 @@ export const RestaurantListView: React.FC<RestaurantListViewProps> = ({
         >
           <div className=" flex-between-center">
             <div className="flex-col gap-1">
-              <h3 className="font-bold">
-                {restaurant.restaurantName}
-              </h3>
-              <p className="text-sm">
-                {restaurant.restaurantCategory}
-              </p>
+              <h3 className="font-bold">{restaurant.restaurantName}</h3>
+              <p className="text-sm">{restaurant.restaurantCategory}</p>
             </div>
             <div className="text-right">
               <div className="text-yellow-400">⭐{restaurant.visitCount}</div>

--- a/gonggibap/src/app/_components/RestaurantListView.tsx
+++ b/gonggibap/src/app/_components/RestaurantListView.tsx
@@ -1,4 +1,5 @@
 import { Restaurant } from "@/types/restaurant";
+import { event } from "@/app/_components/GoogleAnalytics";
 
 type RestaurantListViewProps = {
   restaurants: Restaurant[];
@@ -11,6 +12,29 @@ export const RestaurantListView: React.FC<RestaurantListViewProps> = ({
   onRestaurantSelect,
   selectedRestaurantId,
 }) => {
+  const handleRestaurantSelect = (restaurant: Restaurant) => {
+
+    // GA4 이벤트 발생, 기본적인 선택 이벤트
+    event({
+      action: 'select_restaurant',
+      category: 'engagement',
+      label: restaurant.restaurantName,
+      value: 1,
+    });
+
+    // 상세 정보가 포함된 커스텀 이벤트
+    event({
+      action: 'view_restaurant_details',
+      category: 'restaurant_interaction',
+      label: `${restaurant.restaurantCategory} | ${restaurant.restaurantName}`,
+      value: restaurant.visitCount,
+    });
+
+    // 기존 선택 핸들러 호출
+    onRestaurantSelect(restaurant);
+  };
+
+
   return (
     <div className="space-y-4">
       {restaurants.map((restaurant) => (
@@ -46,3 +70,14 @@ export const RestaurantListView: React.FC<RestaurantListViewProps> = ({
     </div>
   );
 };
+
+// GA4에서 다음과 같은 데이터를 분석할 수 있습니다 ->
+// 어떤 레스토랑이 자주 클릭되는지
+// 카테고리별 인기도
+// 방문 횟수가 높은 레스토랑의 클릭률
+// 사용자의 레스토랑 탐색 패턴
+
+// GA4 대시보드에서는 이러한 이벤트를 기반으로 ->
+// 가장 인기 있는 레스토랑 카테고리
+// 사용자가 가장 많이 조회하는 레스토랑
+// 방문 횟수와 클릭률의 상관관계

--- a/gonggibap/src/app/layout.tsx
+++ b/gonggibap/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { RootProvider } from "@/providers";
+import { GoogleAnalytics } from "@/app/_components/GoogleAnalytics";
 import "./globals.css";
 
 const geistSans = localFont({
@@ -49,7 +50,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <RootProvider>{children}</RootProvider>
+        <RootProvider>
+          {children}
+          <GoogleAnalytics />{" "}
+        </RootProvider>
       </body>
     </html>
   );

--- a/gonggibap/src/app/layout.tsx
+++ b/gonggibap/src/app/layout.tsx
@@ -46,13 +46,13 @@ export default function RootLayout({
 }>) {
   return (
     // 다크모드 전환시 깜빡임 방지를 위해 suppressHydrationWarning 추가
-    <html lang="kr" suppressHydrationWarning>
+    <html lang="ko" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <RootProvider>
           {children}
-          <GoogleAnalytics />{" "}
+          <GoogleAnalytics />
         </RootProvider>
       </body>
     </html>


### PR DESCRIPTION
# 제목
feat/#24/구글 애널리틱스 연결

### 이슈 번호 : #24 

## 📢 변경 사항
- 

## 💬 그 외

### GA4 대시보드에서 확인할 수 있는 주요 인사이트
- 레스토랑별 클릭 빈도
- 카테고리별 사용자 선호도
- 방문 횟수(visitCount)가 높은 레스토랑의 실제 클릭률
- 시간대별 레스토랑 조회 패턴

## ❓ 질문 사항
-

## 📌 JIRA Link
- [관련된 지라 링크](링크)
