### PR TITLE
refactor/#71/컴포넌트 분리

### DIFF
--- a/gonggibap/next.config.mjs
+++ b/gonggibap/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ['gonggibap.s3.ap-northeast-2.amazonaws.com'],
+  },
+};
 
 export default nextConfig;

--- a/gonggibap/src/app/_components/CategoryFilter.tsx
+++ b/gonggibap/src/app/_components/CategoryFilter.tsx
@@ -57,7 +57,7 @@ export const CategoryFilter = ({
   return (
     <div
       className={
-        "fixed left-1/2 -translate-x-1/2 top-4 md:top-4 z-10 transition-all duration-300"
+        "fixed left-1/2 -translate-x-1/2 md:left-[21rem] md:-translate-x-0 top-4 md:top-4 z-10 transition-all duration-300"
       }
     >
       <div className="flex items-center gap-2 p-2 overflow-x-auto">

--- a/gonggibap/src/app/_components/sidebar/MobileSidebar.tsx
+++ b/gonggibap/src/app/_components/sidebar/MobileSidebar.tsx
@@ -146,7 +146,8 @@ export const MobileSidebar: React.FC<MobileSidebarProps> = ({
             onCurrentLocation();
             onRestaurantSelect(null);
           }}
-          className="absolute -top-16 right-4 p-3 bg-white dark:bg-gray-800 rounded-full shadow-lg hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none"
+          className={`absolute -top-16 right-4 p-3 bg-white dark:bg-gray-800 rounded-full shadow-lg hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none
+            ${position === "full" && "hidden"}`}
           aria-label="현재 위치로 이동"
         >
           <PiNavigationArrowBold className="w-6 h-6 text-gray-500 dark:text-gray-300 rotate-90" />

--- a/gonggibap/src/app/_components/sidebar/restaurant/detail/RestaurantDetailView.tsx
+++ b/gonggibap/src/app/_components/sidebar/restaurant/detail/RestaurantDetailView.tsx
@@ -1,22 +1,10 @@
 import { useState } from "react";
-import Image from "next/image";
-import {
-  Trash2,
-  Footprints,
-  Star,
-  MapPin,
-  Phone,
-  CircleUserRound,
-  Coffee,
-  Utensils,
-  ChevronLeft,
-  X,
-} from "lucide-react";
-import { toast } from "react-toastify";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
 import { Restaurant } from "@/types/restaurant";
 import { useAuthStore } from "@/store/useAuthStore";
-import { ReviewForm } from "@/app/_components/sidebar/review/ReviewForm";
+import { RestaurantHeader, RestaurantInfo } from "@/app/_components/sidebar/restaurant/detail";
+import { ReviewForm, ReviewList, ReviewImages } from "@/app/_components/sidebar/review";
 import { useDeleteReview, useGetReviews } from "@/apis/review";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 
@@ -54,255 +42,45 @@ export const RestaurantDetailView: React.FC<RestaurantDetailViewProps> = ({
     });
   };
 
-  const handleMoveToKakaoMap = () => {
-    window.open(`https://place.map.kakao.com/${restaurant.restaurantLink}`);
-  };
-
-  const renderImages = (imageUrls: string[]) => {
-    switch (imageUrls.length) {
-      case 1:
-        return (
-          <div className="h-48">
-            <img
-              src={imageUrls[0]}
-              alt="리뷰 이미지"
-              className="w-full h-full object-cover rounded-lg"
-            />
-          </div>
-        );
-      case 2:
-        return (
-          <div className="flex gap-2 h-48">
-            {imageUrls.map((url) => (
-              <img
-                key={url}
-                src={url}
-                alt="리뷰 이미지"
-                className="w-1/2 h-full object-cover rounded-lg"
-              />
-            ))}
-          </div>
-        );
-      case 3:
-        return (
-          <div className="grid grid-cols-2 gap-2 h-48">
-            <img
-              src={imageUrls[0]}
-              alt="리뷰 이미지"
-              className="h-full w-full object-cover rounded-lg"
-            />
-            <div className="grid grid-rows-2 gap-2 h-full">
-              <img
-                src={imageUrls[1]}
-                alt="리뷰 이미지"
-                className="w-full h-full object-cover rounded-lg"
-              />
-              <img
-                src={imageUrls[2]}
-                alt="리뷰 이미지"
-                className="w-full h-full object-cover rounded-lg"
-              />
-            </div>
-          </div>
-        );
-      case 4:
-        return (
-          <div className="grid grid-cols-2 gap-2 h-48">
-            {imageUrls.map((url) => (
-              <img
-                key={url}
-                src={url}
-                alt="리뷰 이미지"
-                className="w-full h-full object-cover rounded-lg"
-              />
-            ))}
-          </div>
-        );
-      default:
-        return null;
-    }
-  };
-
   return (
     <div className="flex flex-col gap-5">
-      {/* 식당 정보 */}
-      <div className="flex flex-col gap-2">
-        <div className="hidden md:block">
-          <div className="flex-between-center">
-            <button
-              onClick={onClose}
-              className="hover:bg-gray-100 dark:hover:bg-gray-600"
-              aria-label="닫기"
-            >
-              <ChevronLeft size="1.5rem" />
-            </button>
-            <h2 className="text-xl font-bold">{restaurant.restaurantName}</h2>
+      <RestaurantHeader
+        restaurantName={restaurant.restaurantName}
+        onClose={onClose}
+        onBack={onBack}
+      />
 
-            <button
-              onClick={onClose}
-              className="hover:bg-gray-100 dark:hover:bg-gray-600"
-              aria-label="닫기"
-            >
-              <X size="1.5rem" />
-            </button>
-          </div>
-        </div>
+      {reviews && reviews.length > 0 && reviews[0].imageUrls.length > 0 && (
+        <ReviewImages imageUrls={[reviews[0].imageUrls[0]]} />
+      )}
 
-        <div className="block md:hidden">
-          <div className="flex-between-center">
-            <button
-              onClick={onBack}
-              className="rounded dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600"
-              aria-label="뒤로 가기"
-            >
-              <ChevronLeft size="1.5rem" />
-            </button>
-            <h2 className="text-xl font-bold">{restaurant.restaurantName}</h2>
+      <RestaurantInfo restaurant={restaurant} />
 
-            <button
-              onClick={onBack}
-              className="rounded dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600"
-              aria-label="뒤로 가기"
-            >
-              <X size="1.5rem" />
-            </button>
-          </div>
-        </div>
-      </div>
-      <dl className="flex flex-col gap-2">
-        {/* 관련 구청, 평점, 방문 횟수 */}
-        <div className="flex items-center gap-5">
-          <dt className="sr-only">관련 구청</dt>
-          <dd className=""># {restaurant.publicOfficeName}</dd>
-
-          <dt className="sr-only">음식점 평점</dt>
-          <dd className="flex items-center gap-1 text-yellow-400">
-            <Star size="1rem" />
-            {restaurant.pointAvg ? restaurant.pointAvg.toFixed(1) : "-"}
-          </dd>
-
-          <dt className="sr-only">방문 횟수</dt>
-          <dd className="flex items-center gap-1 text-[#FF9A00]">
-            <Footprints size="1rem" /> {restaurant.visitCount}
-          </dd>
-        </div>
-        {/* 카테고리 */}
-        <div>
-          <dt className="sr-only">카테고리</dt>
-          <dd className="flex items-center gap-1">
-            {restaurant.restaurantDetailCategory === "카페" ? (
-              <Coffee size="1rem" />
-            ) : (
-              <Utensils size="1rem" />
-            )}
-            {restaurant.restaurantCategory}
-          </dd>
-        </div>
-        {/* 주소 */}
-        <div>
-          <dt className="sr-only">주소</dt>
-          <dd className="flex items-center gap-1">
-            <MapPin size="1rem" /> {restaurant.restaurantRoadAddressName}
-          </dd>
-        </div>
-        {/* 전화 번호 */}
-        <div>
-          <dt className="sr-only">전화번호</dt>
-          <dd className="flex items-center gap-1">
-            <Phone size="1rem" />{" "}
-            {restaurant.phone
-              ? restaurant.phone
-              : "등록된 전화번호가 없습니다."}
-          </dd>
-        </div>
-        {/* 카카오맵 연결 */}
-        <div>
-          <dt className="sr-only">상세정보 웹사이트</dt>
-          <dd
-            className="flex gap-1 cursor-pointer"
-            onClick={handleMoveToKakaoMap}
-          >
-            <Image
-              src="/images/kakaomap.png"
-              alt="카카오맵"
-              width={24}
-              height={24}
-            />
-            <p>카카오맵 상세정보</p>
-          </dd>
-        </div>
-      </dl>
-
-      {/* 리뷰 작성 창 토글 */}
       {isWriting ? (
-        <div>
-          <ReviewForm
-            restaurantId={restaurant.restaurantId}
-            onClickWriteReview={onClickWriteReview}
-          />
-        </div>
+        <ReviewForm
+          restaurantId={restaurant.restaurantId}
+          onClickWriteReview={onClickWriteReview}
+        />
       ) : (
         <>
-          {/* 리뷰 작성 */}
           <div className="flex justify-end">
             <button
               onClick={onClickWriteReview}
-              className="p-2 rounded-lg text-white bg-[#FF7058] text-right
-            dark:bg-gray-700 md:dark:bg-gray-800"
+              className="p-2 rounded-lg text-white bg-[#FF7058] text-right dark:bg-gray-700 md:dark:bg-gray-800"
             >
               리뷰 작성
             </button>
           </div>
 
-          {/* 리뷰 목록 */}
           <div className="flex flex-col gap-2">
             <h3 className="text-lg font-bold">리뷰</h3>
-            {reviews?.length ? (
-              <ul className="flex flex-col gap-4">
-                {reviews.map((review) => (
-                  <li
-                    key={review.reviewId}
-                    className="flex flex-col gap-1 p-3 dark:bg-gray-700 md:dark:bg-gray-800 rounded-lg border dark:border-none"
-                  >
-                    <div className="flex-between">
-                      <div className="flex-center gap-1">
-                        <CircleUserRound />
-                        <p className="font-bold">{review.userName}</p>
-                      </div>
-                      <p className="text-yellow-400">
-                        {"⭐".repeat(Math.round(review.point))}
-                      </p>
-                    </div>
-
-                    {review.imageUrls.length > 0 &&
-                      renderImages(review.imageUrls)}
-
-                    <p className="text-sm">{review.content}</p>
-                    <div className="flex-between-center">
-                      <time className="text-xs text-gray-400 block">
-                        {review.date}
-                      </time>
-
-                      {review.userId === auth.userInfo?.id && (
-                        <button
-                          onClick={() => handleDeleteReview(review.reviewId)}
-                          disabled={deleteReviewMutation.isPending}
-                          className={`${
-                            deleteReviewMutation.isPending
-                              ? "opacity-50 cursor-not-allowed"
-                              : ""
-                          }`}
-                          aria-label="리뷰 삭제"
-                        >
-                          <Trash2 size={16} />
-                        </button>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-center">작성된 리뷰가 없습니다.</p>
+            {reviews && (
+              <ReviewList
+                reviews={reviews}
+                currentUserId={auth.userInfo?.id}
+                onDeleteReview={handleDeleteReview}
+                isDeleting={deleteReviewMutation.isPending}
+              />
             )}
           </div>
         </>

--- a/gonggibap/src/app/_components/sidebar/restaurant/detail/RestaurantHeader.tsx
+++ b/gonggibap/src/app/_components/sidebar/restaurant/detail/RestaurantHeader.tsx
@@ -1,0 +1,53 @@
+import { ChevronLeft, X } from "lucide-react";
+
+type RestaurantHeaderProps = {
+  restaurantName: string;
+  onClose?: () => void;
+  onBack?: () => void;
+};
+
+export const RestaurantHeader = ({ restaurantName, onClose, onBack }: RestaurantHeaderProps) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="hidden md:block">
+        <div className="flex-between-center">
+          <button
+            onClick={onClose}
+            className="hover:bg-gray-100 dark:hover:bg-gray-600"
+            aria-label="닫기"
+          >
+            <ChevronLeft size="1.5rem" />
+          </button>
+          <h2 className="text-xl font-bold">{restaurantName}</h2>
+          <button
+            onClick={onClose}
+            className="hover:bg-gray-100 dark:hover:bg-gray-600"
+            aria-label="닫기"
+          >
+            <X size="1.5rem" />
+          </button>
+        </div>
+      </div>
+
+      <div className="block md:hidden">
+        <div className="flex-between-center">
+          <button
+            onClick={onBack}
+            className="rounded dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600"
+            aria-label="뒤로 가기"
+          >
+            <ChevronLeft size="1.5rem" />
+          </button>
+          <h2 className="text-xl font-bold">{restaurantName}</h2>
+          <button
+            onClick={onBack}
+            className="rounded dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600"
+            aria-label="뒤로 가기"
+          >
+            <X size="1.5rem" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/gonggibap/src/app/_components/sidebar/restaurant/detail/RestaurantInfo.tsx
+++ b/gonggibap/src/app/_components/sidebar/restaurant/detail/RestaurantInfo.tsx
@@ -1,0 +1,74 @@
+// RestaurantInfo.tsx
+import Image from "next/image";
+import { Star, Footprints, Coffee, Utensils, MapPin, Phone } from "lucide-react";
+import { Restaurant } from "@/types/restaurant";
+
+type RestaurantInfoProps = {
+  restaurant: Restaurant;
+};
+
+export const RestaurantInfo = ({ restaurant }: RestaurantInfoProps) => {
+  const handleMoveToKakaoMap = () => {
+    window.open(`https://place.map.kakao.com/${restaurant.restaurantLink}`);
+  };
+
+  return (
+    <dl className="flex flex-col gap-2">
+      <div className="flex items-center gap-5">
+        <dt className="sr-only">관련 구청</dt>
+        <dd className=""># {restaurant.publicOfficeName}</dd>
+
+        <dt className="sr-only">음식점 평점</dt>
+        <dd className="flex items-center gap-1 text-yellow-400">
+          <Star size="1rem" />
+          {restaurant.pointAvg ? restaurant.pointAvg.toFixed(1) : "-"}
+        </dd>
+
+        <dt className="sr-only">방문 횟수</dt>
+        <dd className="flex items-center gap-1 text-[#FF9A00]">
+          <Footprints size="1rem" /> {restaurant.visitCount}
+        </dd>
+      </div>
+      
+      <div>
+        <dt className="sr-only">카테고리</dt>
+        <dd className="flex items-center gap-1">
+          {restaurant.restaurantDetailCategory === "카페" ? (
+            <Coffee size="1rem" />
+          ) : (
+            <Utensils size="1rem" />
+          )}
+          {restaurant.restaurantCategory}
+        </dd>
+      </div>
+
+      <div>
+        <dt className="sr-only">주소</dt>
+        <dd className="flex items-center gap-1">
+          <MapPin size="1rem" /> {restaurant.restaurantRoadAddressName}
+        </dd>
+      </div>
+
+      <div>
+        <dt className="sr-only">전화번호</dt>
+        <dd className="flex items-center gap-1">
+          <Phone size="1rem" />
+          {restaurant.phone ? restaurant.phone : "등록된 전화번호가 없습니다."}
+        </dd>
+      </div>
+
+      <div>
+        <dt className="sr-only">상세정보 웹사이트</dt>
+        <dd className="flex gap-1 cursor-pointer" onClick={handleMoveToKakaoMap}>
+          <Image
+            src="/images/kakaomap.png"
+            alt="카카오맵"
+            width={24}
+            height={24}
+          />
+          <p>카카오맵 상세정보</p>
+        </dd>
+      </div>
+    </dl>
+  );
+};

--- a/gonggibap/src/app/_components/sidebar/restaurant/detail/index.ts
+++ b/gonggibap/src/app/_components/sidebar/restaurant/detail/index.ts
@@ -1,0 +1,3 @@
+export { RestaurantDetailView } from "@/app/_components/sidebar/restaurant/detail/RestaurantDetailView";
+export { RestaurantHeader } from "@/app/_components/sidebar/restaurant/detail/RestaurantHeader";
+export { RestaurantInfo } from "@/app/_components/sidebar/restaurant/detail/RestaurantInfo";

--- a/gonggibap/src/app/_components/sidebar/review/ReviewForm.tsx
+++ b/gonggibap/src/app/_components/sidebar/review/ReviewForm.tsx
@@ -3,9 +3,9 @@ import { X } from "lucide-react";
 import { toast } from "react-toastify";
 import { useForm } from "react-hook-form";
 import { useQueryClient } from "@tanstack/react-query";
+import { useAuthStore } from "@/store/useAuthStore";
 import { useCreateReview } from "@/apis/review";
 import { QUERY_KEYS } from "@/constants/queryKeys";
-import { useAuthStore } from "@/store/useAuthStore";
 
 type ReviewFormProps = {
   restaurantId: number;

--- a/gonggibap/src/app/_components/sidebar/review/ReviewForm.tsx
+++ b/gonggibap/src/app/_components/sidebar/review/ReviewForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import Image from "next/image";
 import { X } from "lucide-react";
 import { toast } from "react-toastify";
 import { useForm } from "react-hook-form";
@@ -138,11 +139,14 @@ export const ReviewForm: React.FC<ReviewFormProps> = ({
             <div className="flex gap-2">
               {uploadedImages.map((image, index) => (
                 <div key={index} className="relative">
-                  <img
+                  <div className="w-20 h-20">
+                  <Image
                     src={URL.createObjectURL(image)}
                     alt={`업로드 이미지 ${index + 1}`}
-                    className="w-full h-20 object-cover rounded"
+                    className="object-cover rounded"
+                    fill
                   />
+                  </div>
                   <button
                     type="button"
                     onClick={() => handleRemoveImage(index)}

--- a/gonggibap/src/app/_components/sidebar/review/ReviewImages.tsx
+++ b/gonggibap/src/app/_components/sidebar/review/ReviewImages.tsx
@@ -1,0 +1,87 @@
+// RestaurantImageGallery.tsx
+import Image from "next/image";
+
+type ReviewImagesProps = {
+  imageUrls: string[];
+};
+
+export const ReviewImages = ({ imageUrls }: ReviewImagesProps) => {
+  if (imageUrls.length === 0) return null;
+
+  switch (imageUrls.length) {
+    case 1:
+      return (
+        <div className="relative h-48">
+          <Image
+            src={imageUrls[0]}
+            alt="리뷰 이미지"
+            fill
+            className="object-cover rounded-lg"
+          />
+        </div>
+      );
+    case 2:
+      return (
+        <div className="flex gap-2 h-48">
+          {imageUrls.map((url) => (
+            <div key={url} className="relative w-1/2 h-full">
+              <Image
+                src={url}
+                alt="리뷰 이미지"
+                fill
+                className="object-cover rounded-lg"
+              />
+            </div>
+          ))}
+        </div>
+      );
+    case 3:
+      return (
+        <div className="grid grid-cols-2 gap-2 h-48">
+          <div className="relative h-full">
+            <Image
+              src={imageUrls[0]}
+              alt="리뷰 이미지"
+              fill
+              className="object-cover rounded-lg"
+            />
+          </div>
+          <div className="grid grid-rows-2 gap-2 h-full">
+            <div className="relative">
+              <Image
+                src={imageUrls[1]}
+                alt="리뷰 이미지"
+                fill
+                className="object-cover rounded-lg"
+              />
+            </div>
+            <div className="relative">
+              <Image
+                src={imageUrls[2]}
+                alt="리뷰 이미지"
+                fill
+                className="object-cover rounded-lg"
+              />
+            </div>
+          </div>
+        </div>
+      );
+    case 4:
+      return (
+        <div className="grid grid-cols-2 gap-2 h-48">
+          {imageUrls.map((url) => (
+            <div key={url} className="relative h-full">
+              <Image
+                src={url}
+                alt="리뷰 이미지"
+                fill
+                className="object-cover rounded-lg"
+              />
+            </div>
+          ))}
+        </div>
+      );
+    default:
+      return null;
+  }
+};

--- a/gonggibap/src/app/_components/sidebar/review/ReviewList.tsx
+++ b/gonggibap/src/app/_components/sidebar/review/ReviewList.tsx
@@ -1,0 +1,55 @@
+import { CircleUserRound, Trash2 } from "lucide-react";
+import { Review } from "@/types/review";
+import { ReviewImages } from "@/app/_components/sidebar/review";
+
+type ReviewListProps = {
+  reviews: Review[];
+  currentUserId?: number;
+  onDeleteReview: (reviewId: number) => void;
+  isDeleting: boolean;
+};
+
+export const ReviewList = ({ reviews, currentUserId, onDeleteReview, isDeleting }: ReviewListProps) => {
+  if (reviews.length === 0) {
+    return <p className="text-center">작성된 리뷰가 없습니다.</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-4">
+      {reviews.map((review) => (
+        <li
+          key={review.reviewId}
+          className="flex flex-col gap-1 p-3 dark:bg-gray-700 md:dark:bg-gray-800 rounded-lg border dark:border-none"
+        >
+          <div className="flex-between">
+            <div className="flex-center gap-1">
+              <CircleUserRound />
+              <p className="font-bold">{review.userName}</p>
+            </div>
+            <p className="text-yellow-400">{"⭐".repeat(Math.round(review.point))}</p>
+          </div>
+
+          {review.imageUrls.length > 0 && (
+            <ReviewImages imageUrls={review.imageUrls} />
+          )}
+
+          <p className="text-sm">{review.content}</p>
+          <div className="flex-between-center">
+            <time className="text-xs text-gray-400 block">{review.date}</time>
+
+            {review.userId === currentUserId && (
+              <button
+                onClick={() => onDeleteReview(review.reviewId)}
+                disabled={isDeleting}
+                className={`${isDeleting ? "opacity-50 cursor-not-allowed" : ""}`}
+                aria-label="리뷰 삭제"
+              >
+                <Trash2 size={16} />
+              </button>
+            )}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/gonggibap/src/app/_components/sidebar/review/index.ts
+++ b/gonggibap/src/app/_components/sidebar/review/index.ts
@@ -1,0 +1,3 @@
+export { ReviewForm } from "@/app/_components/sidebar/review/ReviewForm";
+export { ReviewImages } from "@/app/_components/sidebar/review/ReviewImages";
+export { ReviewList } from "@/app/_components/sidebar/review/ReviewList";

--- a/gonggibap/src/app/page.tsx
+++ b/gonggibap/src/app/page.tsx
@@ -87,7 +87,7 @@ export default function Home() {
           handleSearch();
           setSelectedRestaurantId(null);
         }}
-        className="fixed left-1/2 -translate-x-1/2 top-20 font-semibold md:top-auto md:bottom-12 flex-center gap-1 bg-[#FF7058] text-white px-4 py-2 md:px-6 md:py-3 text-base md:text-lg rounded-2xl shadow-lg hover:bg-[#FF6147] z-10 focus:outline-none"
+        className="fixed left-1/2 -translate-x-1/2 md:left-[calc(50%+10rem)] top-20 font-semibold md:top-auto md:bottom-12 flex-center gap-1 bg-[#FF7058] text-white px-4 py-2 md:px-6 md:py-3 text-base md:text-lg rounded-2xl shadow-lg hover:bg-[#FF6147] z-10 focus:outline-none"
         aria-label="현 지도에서 재검색"
       >
         <MdRefresh />현 지도에서 재검색


### PR DESCRIPTION
# 제목
refactor/#71/컴포넌트 분리

### 이슈 번호 : #71 

## 📢 변경 사항
- 레스토랑 상세정보 컴포넌트 분리
- img 태그 Image 컴포넌트로 변경
- next Image 설정 추가
- 모바일 하단뷰 full 일 때 내위치로 버튼 숨기기
- 재검색, 필터 위치 조정

## 💬 그 외
-

## ❓ 질문 사항
-

## 📌 JIRA Link
- [관련된 지라 링크](링크)
